### PR TITLE
Integrate gitlab

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,95 +3,100 @@ name: Java CI
 on: [ pull_request ]
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Build with Gradle
-        run: ./gradlew assemble
-        working-directory: code
-  junit-test:
-    needs: build
-    name: JUnit Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Test with JUnit
-        run: |
-          ./gradlew test
-        working-directory: code
-      - name: JUnit Test Report
-        uses: mikepenz/action-junit-report@v2
-        if: always() # always run even if the previous step fails
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-  spotbugs-test:
-    needs: build
-    name: SpotBugs Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Test with SpotBugs
-        run: |
-          ./gradlew spotbugsMain
-          ./gradlew spotbugsTest
-        working-directory: code
-      - name: SpotBugs Test Report
-        uses: jwgmeligmeyling/spotbugs-github-action@master
-        with:
-          path: '**/spotbugsXml.xml'
-          name: 'SpotBugs Test Report'
-  checkstyle-test:
-    needs: build
-    name: Checkstyle Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Test with Checkstyle
-        run: ./gradlew check
-        working-directory: code
-      - uses: jwgmeligmeyling/checkstyle-github-action@master
-        with:
-          path: '**/checkstyle/*.xml'
-  spotless-java-format-test:
-    needs: build
-    name: Spotless Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Test with Spotless
-        run: ./gradlew spotlessJavaCheck
-        working-directory: code
+
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v2
+                with:
+                    java-version: '17'
+                    distribution: 'adopt'
+            -   name: Validate Gradle wrapper
+                uses: gradle/wrapper-validation-action@v1
+            -   name: Build with Gradle
+                run: ./gradlew assemble
+                working-directory: code
+
+    junit-test:
+        needs: build
+        name: JUnit Test
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v2
+                with:
+                    java-version: '17'
+                    distribution: 'adopt'
+            -   name: Test with JUnit
+                run: |
+                    ./gradlew test
+                working-directory: code
+            -   name: JUnit Test Report
+                uses: mikepenz/action-junit-report@v2
+                if: always() # always run even if the previous step fails
+                with:
+                    report_paths: '**/build/test-results/test/TEST-*.xml'
+
+    spotbugs-test:
+        needs: build
+        name: SpotBugs Test
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v2
+                with:
+                    java-version: '17'
+                    distribution: 'adopt'
+            -   name: Test with SpotBugs
+                run: |
+                    ./gradlew spotbugsMain
+                    ./gradlew spotbugsTest
+                working-directory: code
+            -   name: SpotBugs Test Report
+                uses: jwgmeligmeyling/spotbugs-github-action@master
+                with:
+                    path: '**/spotbugsXml.xml'
+                    name: 'SpotBugs Test Report'
+
+    checkstyle-test:
+        needs: build
+        name: Checkstyle Test
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v2
+                with:
+                    java-version: '17'
+                    distribution: 'adopt'
+            -   name: Test with Checkstyle
+                run: ./gradlew check
+                working-directory: code
+            -   uses: jwgmeligmeyling/checkstyle-github-action@master
+                with:
+                    path: '**/checkstyle/*.xml'
+
+    spotless-java-format-test:
+        needs: build
+        name: Spotless Test
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v2
+                with:
+                    java-version: '17'
+                    distribution: 'adopt'
+            -   name: Test with Spotless
+                run: ./gradlew spotlessJavaCheck
+                working-directory: code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           path: '**/spotbugsXml.xml'
           name: 'SpotBugs Test Report'
   checkstyle-test:
+    needs: build
     name: Checkstyle Test
     runs-on: ubuntu-latest
     steps:
@@ -80,6 +81,7 @@ jobs:
         with:
           path: '**/checkstyle/*.xml'
   spotless-java-format-test:
+    needs: build
     name: Spotless Test
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -156,10 +156,14 @@ latex.out/
 
 
 # IntelliJ IDEA #
-#########
+#################
 .idea
 
 # Gradle #
-#########
+##########
 .gradle/
 war/
+
+# GitLab #
+##########
+code/output_*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,4 @@ war/
 
 # GitLab #
 ##########
-code/output_*.txt
+code/*_log.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ build-job:
         - ./gradlew assemble > assemble.txt 2>&1
         - echo "Compile complete."
     artifacts:
+        when: always
         paths:
             - code/assemble.txt
 
@@ -22,6 +23,7 @@ junit-job:
         - ./gradlew test > junit.txt 2>&1
         - echo "JUnit tests complete."
     artifacts:
+        when: always
         paths:
             - code/junit.txt
 
@@ -34,6 +36,7 @@ spotbugs-job:
         - ./gradlew spotbugsTest > spotbugsTest.txt 2>&1
         - echo "SpotBugs tests complete."
     artifacts:
+        when: always
         paths:
             - code/spotbugsMain.txt
             - code/spotbugsTest.txt
@@ -46,6 +49,7 @@ checkstyle-job:
         - ./gradlew check > checkstyle.txt 2>&1
         - echo "Checkstyle complete."
     artifacts:
+        when: always
         paths:
             - code/checkstyle.txt
 
@@ -57,6 +61,7 @@ spotless-job:
         - ./gradlew spotlessJavaCheck > spotless.txt 2>&1
         - echo "Spotless complete."
     artifacts:
+        when: always
         paths:
             - code/spotless.txt
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,14 @@
 stages:
     - build
     - test
+    - package
 
 build-job:
     stage: build
     script:
         - echo "Compiling the code..."
         - cd code
-        - ./gradlew assemble
+        - ./gradlew assemble > assemble.txt
         - echo "Compile complete."
 
 junit-job:
@@ -15,7 +16,7 @@ junit-job:
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test
+        - ./gradlew test > junit.txt
         - echo "JUnit tests complete."
 
 spotbugs-job:
@@ -23,8 +24,8 @@ spotbugs-job:
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain
-        - ./gradlew spotbugsTest
+        - ./gradlew spotbugsMain > spotbugsMain.txt
+        - ./gradlew spotbugsTest > spotbugsTest.txt
         - echo "SpotBugs tests complete."
 
 checkstyle-job:
@@ -32,7 +33,7 @@ checkstyle-job:
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check
+        - ./gradlew check > checkstyle.txt
         - echo "Checkstyle complete."
 
 spotless-job:
@@ -40,5 +41,14 @@ spotless-job:
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck
+        - ./gradlew spotlessJavaCheck > spotless.txt
         - echo "Spotless complete."
+
+package-job:
+    stage: package
+    script:
+        - cd code
+        - cat assemble.txt junit.txt spotbugsMain.txt spotbugsTest.txt checkstyle.txt spotless.txt | gzip > tests.gz
+    artifacts:
+        paths:
+            - tests.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 stages:
     - build
-    - check
     - test
+    - check
     - package
 
 build-job:
@@ -16,20 +16,33 @@ build-job:
         paths:
             - code/output_1.txt
 
+junit-job:
+    when: always
+    stage: test
+    script:
+        - echo "Running JUnit tests..."
+        - cd code
+        - ./gradlew test 2>&1 | tee output_2.txt
+        - echo "JUnit tests complete."
+    artifacts:
+        when: always
+        paths:
+            - code/output_2.txt
+
 spotbugs-job:
     when: always
     stage: check
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain 2>&1 | tee output_2.txt
-        - ./gradlew spotbugsTest 2>&1 | tee output_3.txt
+        - ./gradlew spotbugsMain 2>&1 | tee output_3.txt
+        - ./gradlew spotbugsTest 2>&1 | tee output_4.txt
         - echo "SpotBugs tests complete."
     artifacts:
         when: always
         paths:
-            - code/output_2.txt
             - code/output_3.txt
+            - code/output_4.txt
 
 checkstyle-job:
     when: always
@@ -37,12 +50,12 @@ checkstyle-job:
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check 2>&1 | tee output_4.txt
+        - ./gradlew check 2>&1 | tee output_5.txt
         - echo "Checkstyle complete."
     artifacts:
         when: always
         paths:
-            - code/output_4.txt
+            - code/output_5.txt
 
 spotless-job:
     when: always
@@ -50,21 +63,8 @@ spotless-job:
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck 2>&1 | tee output_5.txt
+        - ./gradlew spotlessJavaCheck 2>&1 | tee output_6.txt
         - echo "Spotless complete."
-    artifacts:
-        when: always
-        paths:
-            - code/output_5.txt
-
-junit-job:
-    when: always
-    stage: test
-    script:
-        - echo "Running JUnit tests..."
-        - cd code
-        - ./gradlew test 2>&1 | tee output_6.txt
-        - echo "JUnit tests complete."
     artifacts:
         when: always
         paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build-job:
         - ./gradlew assemble
         - echo "Compile complete."
 
-junit-test-job:
+junit-job:
     stage: test
     script:
         - echo "Running JUnit tests..."
@@ -18,7 +18,7 @@ junit-test-job:
         - ./gradlew test
         - echo "JUnit tests complete."
 
-spotbugs-test-job:
+spotbugs-job:
     stage: test
     script:
         - echo "Running SpotBugs tests..."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,9 @@ build-job:
         - cd code
         - ./gradlew assemble > assemble.txt
         - echo "Compile complete."
+    artifacts:
+        paths:
+            - code/assemble.txt
 
 junit-job:
     stage: test
@@ -18,6 +21,9 @@ junit-job:
         - cd code
         - ./gradlew test > junit.txt
         - echo "JUnit tests complete."
+    artifacts:
+        paths:
+            - code/junit.txt
 
 spotbugs-job:
     stage: test
@@ -27,6 +33,10 @@ spotbugs-job:
         - ./gradlew spotbugsMain > spotbugsMain.txt
         - ./gradlew spotbugsTest > spotbugsTest.txt
         - echo "SpotBugs tests complete."
+    artifacts:
+        paths:
+            - code/spotbugsMain.txt
+            - code/spotbugsTest.txt
 
 checkstyle-job:
     stage: test
@@ -35,6 +45,9 @@ checkstyle-job:
         - cd code
         - ./gradlew check > checkstyle.txt
         - echo "Checkstyle complete."
+    artifacts:
+        paths:
+            - code/checkstyle.txt
 
 spotless-job:
     stage: test
@@ -43,6 +56,9 @@ spotless-job:
         - cd code
         - ./gradlew spotlessJavaCheck > spotless.txt
         - echo "Spotless complete."
+    artifacts:
+        paths:
+            - code/spotless.txt
 
 package-job:
     stage: package
@@ -51,4 +67,4 @@ package-job:
         - cat assemble.txt junit.txt spotbugsMain.txt spotbugsTest.txt checkstyle.txt spotless.txt | gzip > tests.gz
     artifacts:
         paths:
-            - tests.gz
+            - code/tests.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,8 @@ package-job:
     when: always
     stage: package
     script:
-        - cat code/output_*.txt 2>&1 | tee output_7.txt
+        - cd code
+        - cat output_*.txt 2>&1 | tee output_7.txt
     artifacts:
         paths:
-            - output_7.txt
+            - code/output_7.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,71 +8,73 @@ build-job:
     script:
         - echo "Compiling the code..."
         - cd code
-        - ./gradlew assemble > assemble.txt 2>&1
+        - ./gradlew assemble 2>&1 | tee output_1.txt
         - echo "Compile complete."
     artifacts:
         when: always
         paths:
-            - code/assemble.txt
+            - code/output_1.txt
 
 junit-job:
+    when: always
     stage: test
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test > junit.txt 2>&1
+        - ./gradlew test 2>&1 | tee output_2.txt
         - echo "JUnit tests complete."
     artifacts:
         when: always
         paths:
-            - code/junit.txt
+            - code/output_2.txt
 
 spotbugs-job:
+    when: always
     stage: test
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain > spotbugsMain.txt 2>&1
-        - ./gradlew spotbugsTest > spotbugsTest.txt 2>&1
+        - ./gradlew spotbugsMain 2>&1 | tee output_3.txt
+        - ./gradlew spotbugsTest 2>&1 | tee output_4.txt
         - echo "SpotBugs tests complete."
     artifacts:
         when: always
         paths:
-            - code/spotbugsMain.txt
-            - code/spotbugsTest.txt
+            - code/output_3.txt
+            - code/output_4.txt
 
 checkstyle-job:
+    when: always
     stage: test
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check > checkstyle.txt 2>&1
+        - ./gradlew check 2>&1 | tee output_5.txt
         - echo "Checkstyle complete."
     artifacts:
         when: always
         paths:
-            - code/checkstyle.txt
+            - code/output_5.txt
 
 spotless-job:
+    when: always
     stage: test
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck > spotless.txt 2>&1
+        - ./gradlew spotlessJavaCheck 2>&1 | tee output_6.txt
         - echo "Spotless complete."
     artifacts:
         when: always
         paths:
-            - code/spotless.txt
+            - code/output_6.txt
 
 package-job:
     when: always
     stage: package
     script:
         - cd code
-        - cat assemble.txt junit.txt spotbugsMain.txt spotbugsTest.txt checkstyle.txt spotless.txt > tests.txt
-        - gzip -k tests.txt
+        - cat output_*.txt 2>&1 | tee output_7.txt
     artifacts:
         paths:
-            - code/tests.txt
-            - code/tests.txt.gz
+            - code/output_7.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,12 @@ build-job:
     script:
         - echo "Compiling the code..."
         - cd code
-        - ./gradlew assemble 2>&1 | tee output_1.txt
+        - ./gradlew assemble 2>&1 | tee 01_assemble_log.txt
         - echo "Compile complete."
     artifacts:
         when: always
         paths:
-            - code/output_1.txt
+            - code/01_assemble_log.txt
 
 junit-job:
     when: always
@@ -22,12 +22,12 @@ junit-job:
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test 2>&1 | tee output_2.txt
+        - ./gradlew test 2>&1 | tee 02_junit_log.txt
         - echo "JUnit tests complete."
     artifacts:
         when: always
         paths:
-            - code/output_2.txt
+            - code/02_junit_log.txt
 
 spotbugs-job:
     when: always
@@ -35,14 +35,14 @@ spotbugs-job:
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain 2>&1 | tee output_3.txt
-        - ./gradlew spotbugsTest 2>&1 | tee output_4.txt
+        - ./gradlew spotbugsMain 2>&1 | tee 03_spotbugs_log.txt
+        - ./gradlew spotbugsTest 2>&1 | tee 04_spotbugs_log.txt
         - echo "SpotBugs tests complete."
     artifacts:
         when: always
         paths:
-            - code/output_3.txt
-            - code/output_4.txt
+            - code/03_spotbugs_log.txt
+            - code/04_spotbugs_log.txt
 
 checkstyle-job:
     when: always
@@ -50,12 +50,12 @@ checkstyle-job:
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check 2>&1 | tee output_5.txt
+        - ./gradlew check 2>&1 | tee 05_checkstyle_log.txt
         - echo "Checkstyle complete."
     artifacts:
         when: always
         paths:
-            - code/output_5.txt
+            - code/05_checkstyle_log.txt
 
 spotless-job:
     when: always
@@ -63,19 +63,19 @@ spotless-job:
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck 2>&1 | tee output_6.txt
+        - ./gradlew spotlessJavaCheck 2>&1 | tee 06_spotless_log.txt
         - echo "Spotless complete."
     artifacts:
         when: always
         paths:
-            - code/output_6.txt
+            - code/06_spotless_log.txt
 
 package-job:
     when: always
     stage: package
     script:
         - cd code
-        - cat output_*.txt 2>&1 | tee output_7.txt
+        - cat *_log.txt 2>&1 | tee 07_summary_log.txt
     artifacts:
         paths:
-            - code/output_7.txt
+            - code/07_summary_log.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+stages:
+    - build
+
+build-job:
+    stage: build
+    script:
+        - echo "Compiling the code..."
+        - cd code
+        - ./gradlew assemble
+        - echo "Compile complete."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
     - build
+    - test
 
 build-job:
     stage: build
@@ -8,3 +9,36 @@ build-job:
         - cd code
         - ./gradlew assemble
         - echo "Compile complete."
+
+junit-test-job:
+    stage: test
+    script:
+        - echo "Running JUnit tests..."
+        - cd code
+        - ./gradlew test
+        - echo "JUnit tests complete."
+
+spotbugs-test-job:
+    stage: test
+    script:
+        - echo "Running SpotBugs tests..."
+        - cd code
+        - ./gradlew spotbugsMain
+        - ./gradlew spotbugsTest
+        - echo "SpotBugs tests complete."
+
+checkstyle-job:
+    stage: test
+    script:
+        - echo "Checkstyle..."
+        - cd code
+        - ./gradlew check
+        - echo "Checkstyle complete."
+
+spotless-job:
+    stage: test
+    script:
+        - echo "Spotless..."
+        - cd code
+        - ./gradlew spotlessJavaCheck
+        - echo "Spotless complete."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,7 @@ spotless-job:
             - code/spotless.txt
 
 package-job:
+    when: always
     stage: package
     script:
         - cd code

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
     - build
+    - check
     - test
     - package
 
@@ -15,55 +16,55 @@ build-job:
         paths:
             - code/output_1.txt
 
+spotbugs-job:
+    when: always
+    stage: check
+    script:
+        - echo "Running SpotBugs tests..."
+        - cd code
+        - ./gradlew spotbugsMain 2>&1 | tee output_2.txt
+        - ./gradlew spotbugsTest 2>&1 | tee output_3.txt
+        - echo "SpotBugs tests complete."
+    artifacts:
+        when: always
+        paths:
+            - code/output_2.txt
+            - code/output_3.txt
+
+checkstyle-job:
+    when: always
+    stage: check
+    script:
+        - echo "Checkstyle..."
+        - cd code
+        - ./gradlew check 2>&1 | tee output_4.txt
+        - echo "Checkstyle complete."
+    artifacts:
+        when: always
+        paths:
+            - code/output_4.txt
+
+spotless-job:
+    when: always
+    stage: check
+    script:
+        - echo "Spotless..."
+        - cd code
+        - ./gradlew spotlessJavaCheck 2>&1 | tee output_5.txt
+        - echo "Spotless complete."
+    artifacts:
+        when: always
+        paths:
+            - code/output_5.txt
+
 junit-job:
     when: always
     stage: test
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test 2>&1 | tee output_2.txt
+        - ./gradlew test 2>&1 | tee output_6.txt
         - echo "JUnit tests complete."
-    artifacts:
-        when: always
-        paths:
-            - code/output_2.txt
-
-spotbugs-job:
-    when: always
-    stage: test
-    script:
-        - echo "Running SpotBugs tests..."
-        - cd code
-        - ./gradlew spotbugsMain 2>&1 | tee output_3.txt
-        - ./gradlew spotbugsTest 2>&1 | tee output_4.txt
-        - echo "SpotBugs tests complete."
-    artifacts:
-        when: always
-        paths:
-            - code/output_3.txt
-            - code/output_4.txt
-
-checkstyle-job:
-    when: always
-    stage: test
-    script:
-        - echo "Checkstyle..."
-        - cd code
-        - ./gradlew check 2>&1 | tee output_5.txt
-        - echo "Checkstyle complete."
-    artifacts:
-        when: always
-        paths:
-            - code/output_5.txt
-
-spotless-job:
-    when: always
-    stage: test
-    script:
-        - echo "Spotless..."
-        - cd code
-        - ./gradlew spotlessJavaCheck 2>&1 | tee output_6.txt
-        - echo "Spotless complete."
     artifacts:
         when: always
         paths:
@@ -73,8 +74,7 @@ package-job:
     when: always
     stage: package
     script:
-        - cd code
-        - cat output_*.txt 2>&1 | tee output_7.txt
+        - cat code/output_*.txt 2>&1 | tee output_7.txt
     artifacts:
         paths:
-            - code/output_7.txt
+            - output_7.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,9 @@ package-job:
     stage: package
     script:
         - cd code
-        - cat assemble.txt junit.txt spotbugsMain.txt spotbugsTest.txt checkstyle.txt spotless.txt | gzip > tests.gz
+        - cat assemble.txt junit.txt spotbugsMain.txt spotbugsTest.txt checkstyle.txt spotless.txt > tests.txt
+        - gzip -k tests.txt
     artifacts:
         paths:
-            - code/tests.gz
+            - code/tests.txt
+            - code/tests.txt.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ build-job:
     script:
         - echo "Compiling the code..."
         - cd code
-        - ./gradlew assemble &> assemble.txt
+        - ./gradlew assemble > assemble.txt 2>&1
         - echo "Compile complete."
     artifacts:
         paths:
@@ -19,7 +19,7 @@ junit-job:
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test &> junit.txt
+        - ./gradlew test > junit.txt 2>&1
         - echo "JUnit tests complete."
     artifacts:
         paths:
@@ -30,8 +30,8 @@ spotbugs-job:
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain &> spotbugsMain.txt
-        - ./gradlew spotbugsTest &> spotbugsTest.txt
+        - ./gradlew spotbugsMain > spotbugsMain.txt 2>&1
+        - ./gradlew spotbugsTest > spotbugsTest.txt 2>&1
         - echo "SpotBugs tests complete."
     artifacts:
         paths:
@@ -43,7 +43,7 @@ checkstyle-job:
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check &> checkstyle.txt
+        - ./gradlew check > checkstyle.txt 2>&1
         - echo "Checkstyle complete."
     artifacts:
         paths:
@@ -54,7 +54,7 @@ spotless-job:
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck &> spotless.txt
+        - ./gradlew spotlessJavaCheck > spotless.txt 2>&1
         - echo "Spotless complete."
     artifacts:
         paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ build-job:
     script:
         - echo "Compiling the code..."
         - cd code
-        - ./gradlew assemble > assemble.txt
+        - ./gradlew assemble &> assemble.txt
         - echo "Compile complete."
     artifacts:
         paths:
@@ -19,7 +19,7 @@ junit-job:
     script:
         - echo "Running JUnit tests..."
         - cd code
-        - ./gradlew test > junit.txt
+        - ./gradlew test &> junit.txt
         - echo "JUnit tests complete."
     artifacts:
         paths:
@@ -30,8 +30,8 @@ spotbugs-job:
     script:
         - echo "Running SpotBugs tests..."
         - cd code
-        - ./gradlew spotbugsMain > spotbugsMain.txt
-        - ./gradlew spotbugsTest > spotbugsTest.txt
+        - ./gradlew spotbugsMain &> spotbugsMain.txt
+        - ./gradlew spotbugsTest &> spotbugsTest.txt
         - echo "SpotBugs tests complete."
     artifacts:
         paths:
@@ -43,7 +43,7 @@ checkstyle-job:
     script:
         - echo "Checkstyle..."
         - cd code
-        - ./gradlew check > checkstyle.txt
+        - ./gradlew check &> checkstyle.txt
         - echo "Checkstyle complete."
     artifacts:
         paths:
@@ -54,7 +54,7 @@ spotless-job:
     script:
         - echo "Spotless..."
         - cd code
-        - ./gradlew spotlessJavaCheck > spotless.txt
+        - ./gradlew spotlessJavaCheck &> spotless.txt
         - echo "Spotless complete."
     artifacts:
         paths:

--- a/code/desktop/src/desktop/DesktopLauncher.java
+++ b/code/desktop/src/desktop/DesktopLauncher.java
@@ -7,7 +7,7 @@ import controller.MainController;
 import tools.Constants;
 
 public final class DesktopLauncher {
-    public static void run(MainController mc)  {
+    public static void run(MainController mc)
         LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
         config.width = Constants.WINDOW_WIDTH;
         config.height = Constants.WINDOW_HEIGHT;

--- a/code/desktop/src/desktop/DesktopLauncher.java
+++ b/code/desktop/src/desktop/DesktopLauncher.java
@@ -7,7 +7,7 @@ import controller.MainController;
 import tools.Constants;
 
 public final class DesktopLauncher {
-    public static void run(MainController mc) {
+    public static void run(MainController mc)  {
         LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
         config.width = Constants.WINDOW_WIDTH;
         config.height = Constants.WINDOW_HEIGHT;

--- a/code/desktop/src/desktop/DesktopLauncher.java
+++ b/code/desktop/src/desktop/DesktopLauncher.java
@@ -7,7 +7,7 @@ import controller.MainController;
 import tools.Constants;
 
 public final class DesktopLauncher {
-    public static void run(MainController mc)
+    public static void run(MainController mc) {
         LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
         config.width = Constants.WINDOW_WIDTH;
         config.height = Constants.WINDOW_HEIGHT;

--- a/code/desktop/src/desktop/DesktopLauncher.java
+++ b/code/desktop/src/desktop/DesktopLauncher.java
@@ -7,7 +7,7 @@ import controller.MainController;
 import tools.Constants;
 
 public final class DesktopLauncher {
-    public static void run(MainController mc) {
+    public static void run(MainController mc)
         LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
         config.width = Constants.WINDOW_WIDTH;
         config.height = Constants.WINDOW_HEIGHT;


### PR DESCRIPTION
Fixes #18

- Die `.github/workflows/test.yml` und die `.gitlab-ci.yml` verhalten sich jetzt gleich
- Der build step ist Voraussetzung für alle anderen Steps (im GH und GL)
- Wenn ein Fehler im build step auftritt, dann werden die Tests gar nicht erst gestartet
- Der artifacts step wird jedoch IMMER gestartet
- Man kann sich jetzt im GL ein Artefakt mit allen Ausgaben herunterladen:

![image](https://user-images.githubusercontent.com/85501570/152640076-b4f33392-4b86-4eb8-8b9f-fdf2eb63c786.png)

- Auch, wenn ein Test fehlschlug:

![image](https://user-images.githubusercontent.com/85501570/152640100-bbc87217-ffa4-4115-b75e-2b5aff4d03de.png)

- Schlägt jedoch der build step fehl, so kann man kein package mehr herunterladen, jedoch den fehlgeschlagenen build step herunterladen:

![image](https://user-images.githubusercontent.com/85501570/152640166-64bb5b13-d4d4-44d4-8eae-02218d7c877f.png)
